### PR TITLE
Dev/embed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,18 @@
 module github.com/defektive/fast-resolv
 
-go 1.13
+go 1.17
 
 require (
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
-	github.com/miekg/dns v1.1.22
-	github.com/miekg/unbound v0.0.0-20180419064740-e2b53b2dbcba
+	github.com/miekg/dns v1.1.44
+	github.com/miekg/unbound v0.0.0-20210309082708-dbeefb4cdb29
+)
+
+require (
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	golang.org/x/mod v0.5.1 // indirect
+	golang.org/x/net v0.0.0-20211216030914-fe4d6282115f // indirect
+	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
+	golang.org/x/tools v0.1.8 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 )


### PR DESCRIPTION
- Embeding the fast-resolv.conf in the binary.
- Creating `~/.fast-resolv` and placing the fast-resolv.conf file there

Why?
If `fast-resolv` was installed via `go get` or `go install`, the `fast-resolv.conf` file would have to be taken from the repo and copied to the go bin directory in order for it to even be used. This way, you can install `fast-resolv` via `go get` or `go install` and it will write `fast-resolv.conf` to `~/.fast-resolv` if it doesn't exist.
